### PR TITLE
fix crash when device is busy

### DIFF
--- a/plugins/videoUNICAP/videoUNICAP.cpp
+++ b/plugins/videoUNICAP/videoUNICAP.cpp
@@ -386,6 +386,10 @@ bool videoUNICAP :: start(void)
     return false;
   }
   post_fmt(&format);
+  if(format.size_count<1 || format.sizes==NULL){
+	  error("Can't get supported format. Device might be busy.");
+	  return false;
+  }
 
   if(default_size>format.size_count) {
     debugPost("oops: want size #%d of %d", default_size, format.size_count);


### PR DESCRIPTION
according to libunicap documentation, format.sizes could be NULL.

Signed-off-by: antoine@nusmuk-12.04 antoine.villeret@gmail.com
