### PR TITLE
Don't instanciate variable if it doesn't exist

### DIFF
--- a/src/Base/GemContext.cpp
+++ b/src/Base/GemContext.cpp
@@ -60,7 +60,7 @@ public:
     xcontext(new GemGlewXContext(*p.xcontext)),
 # endif /* GemGlewXContext */
 #else
-    context(NULL), xcontext(NULL),
+    context(NULL),
 #endif
     contextid(makeID())
   {


### PR DESCRIPTION
see line 88 where `xcontext` is declared only if `GemGlewXContext` is defined
