### PR TITLE
change sleep time of pix_film's grabThread() from 100us to 5ms

### DIFF
--- a/src/Pixes/pix_film.cpp
+++ b/src/Pixes/pix_film.cpp
@@ -162,8 +162,8 @@ void *pix_film :: grabThread(void*you)
       me->m_curTrack=reqTrack;
 
       pthread_mutex_unlock(me->m_mutex);
-    }
-    gem::thread::usleep(100);
+      gem::thread::usleep(100);
+    } else gem::thread::usleep(5000);
   }
 
   pthread_mutex_lock  (me->m_mutex);


### PR DESCRIPTION
Currently 10 [pix_film]s loaded with any movie eat approx. 50% of my 2GHz CPU (given by Pd's CPU-meter), although none of the pix_film is connected from a [gemhead], none is playing (auto off/no frame input), and no Gem window is even opened (no rendering). Pd's DSP is also off. Of course CPU is loaded as much when rendering is on.

So I tried to change the sleep time of grabThread() to 5ms (which I think is enough, more than 100FPS movies are not so common) when frame didn't change, then CPU usage for 10 loaded pix_films fell down to 3%.

This can help creating many players and preloading them before the set begins... without eating the CPU while the films don't play.