### PR TITLE
Fix bad memory access in RTE::addSearchPath

### DIFF
--- a/src/RTE/RTE.cpp
+++ b/src/RTE/RTE.cpp
@@ -186,7 +186,7 @@ bool RTE::addSearchPath(const std::string&path, void* ctx)
     char encoded[MAXPDSTRING];
     char*outptr = encoded;
     *outptr++='+';
-    while(inptr && ((outptr+2) < (encoded+MAXPDSTRING))) {
+    while(inptr && *inptr && ((outptr+2) < (encoded+MAXPDSTRING))) {
       *outptr++ = *inptr++;
       if ('+'==inptr[-1]) {
         *outptr++='+';


### PR DESCRIPTION
In RTE::addSearchPath, prevent reading past the end of the string (path argument) to avoid bad memory accesses.

This one was found by valgrind. I didn't actually experience segfaults because of this, but if you look at the code, there's a check for the end of the string data missing in the loop there which encodes the path name. This changeset just adds a check `*inptr` to make sure that we don't read past the end of the string there.

Note that I also left the orgininal `inptr` check in there for extra safety, although I suspect that this was a typo and actually intended to be `*inptr` in the first place.