### PR TITLE
add anti-aliasing to gemmacoswindow

### DIFF
--- a/src/Output/gemmacoswindow.mm
+++ b/src/Output/gemmacoswindow.mm
@@ -117,7 +117,7 @@ typedef GLint oglc_setvalue_t;
   [super prepareOpenGL];
   glEnable(GL_MULTISAMPLE);
   oglc_setvalue_t swapRect = 0;
-  [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLCPSwapRectangleEnable];
+  [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLContextParameterSwapRectangleEnable];
 }
 
 - (void)drawRect:(NSRect)rect

--- a/src/Output/gemmacoswindow.mm
+++ b/src/Output/gemmacoswindow.mm
@@ -429,7 +429,13 @@ bool gemmacoswindow :: create(void)
   attrvec.push_back(NSOpenGLPFAColorSize);
   attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
   attrvec.push_back(NSOpenGLPFADepthSize);
-  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(23));
+  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
+  attrvec.push_back(NSOpenGLPFASampleBuffers);
+  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(8));
+  attrvec.push_back(NSOpenGLPFASamples);
+  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
+  attrvec.push_back(NSOpenGLPFANoRecovery);
+  attrvec.push_back(NSOpenGLPFAMultisample);
   if(m_fullscreen) {
 	  // [window setContentView: m_pimpl->view]; // maybe this? doesnt seem to work though
 	  //attrvec.push_back(NSOpenGLPFAFullScreen); // depreciated

--- a/src/Output/gemmacoswindow.mm
+++ b/src/Output/gemmacoswindow.mm
@@ -113,6 +113,8 @@ typedef GLint oglc_setvalue_t;
   oglc_setvalue_t swapInt = 1; // 1==sync to vblank
   [[self openGLContext] setValues:&swapInt forParameter:NSOpenGLCPSwapInterval]; // set to vbl sync
 #endif
+	
+  [super prepareOpenGL];
   oglc_setvalue_t swapRect = 0;
   [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLContextParameterSwapRectangleEnable];
 }

--- a/src/Output/gemmacoswindow.mm
+++ b/src/Output/gemmacoswindow.mm
@@ -117,7 +117,7 @@ typedef GLint oglc_setvalue_t;
   [super prepareOpenGL];
   glEnable(GL_MULTISAMPLE);
   oglc_setvalue_t swapRect = 0;
-  [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLContextParameterSwapRectangleEnable];
+  [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLCPSwapRectangleEnable];
 }
 
 - (void)drawRect:(NSRect)rect
@@ -429,15 +429,7 @@ bool gemmacoswindow :: create(void)
   attrvec.push_back(NSOpenGLPFAColorSize);
   attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
   attrvec.push_back(NSOpenGLPFADepthSize);
-  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
-  attrvec.push_back(NSOpenGLPFASampleBuffers);
-  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(8));
-  attrvec.push_back(NSOpenGLPFASamples);
-  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
-  attrvec.push_back(NSOpenGLPFANoRecovery);
-  attrvec.push_back(NSOpenGLPFAMultisample);
-  
-  
+  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(23));
   if(m_fullscreen) {
 	  // [window setContentView: m_pimpl->view]; // maybe this? doesnt seem to work though
 	  //attrvec.push_back(NSOpenGLPFAFullScreen); // depreciated

--- a/src/Output/gemmacoswindow.mm
+++ b/src/Output/gemmacoswindow.mm
@@ -114,7 +114,7 @@ typedef GLint oglc_setvalue_t;
   [[self openGLContext] setValues:&swapInt forParameter:NSOpenGLCPSwapInterval]; // set to vbl sync
 #endif
   oglc_setvalue_t swapRect = 0;
-  [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLCPSwapRectangleEnable];
+  [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLContextParameterSwapRectangleEnable];
 }
 
 - (void)drawRect:(NSRect)rect
@@ -426,7 +426,15 @@ bool gemmacoswindow :: create(void)
   attrvec.push_back(NSOpenGLPFAColorSize);
   attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
   attrvec.push_back(NSOpenGLPFADepthSize);
-  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(23));
+  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
+  attrvec.push_back(NSOpenGLPFASampleBuffers);
+  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(8));
+  attrvec.push_back(NSOpenGLPFASamples);
+  attrvec.push_back(static_cast<NSOpenGLPixelFormatAttribute>(32));
+  attrvec.push_back(NSOpenGLPFANoRecovery);
+  attrvec.push_back(NSOpenGLPFAMultisample);
+  
+  
   if(m_fullscreen) {
 	  // [window setContentView: m_pimpl->view]; // maybe this? doesnt seem to work though
 	  //attrvec.push_back(NSOpenGLPFAFullScreen); // depreciated

--- a/src/Output/gemmacoswindow.mm
+++ b/src/Output/gemmacoswindow.mm
@@ -115,6 +115,7 @@ typedef GLint oglc_setvalue_t;
 #endif
 	
   [super prepareOpenGL];
+  glEnable(GL_MULTISAMPLE);
   oglc_setvalue_t swapRect = 0;
   [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLContextParameterSwapRectangleEnable];
 }

--- a/src/Output/gemmacoswindow.mm
+++ b/src/Output/gemmacoswindow.mm
@@ -115,7 +115,7 @@ typedef GLint oglc_setvalue_t;
 #endif
 	
   [super prepareOpenGL];
-  glEnable(GL_MULTISAMPLE);
+  glEnable(GL_MULTISAMPLE); // Enable multisampling for anti-aliasing (although this may not be necessary)
   oglc_setvalue_t swapRect = 0;
   [[self openGLContext] setValues:&swapRect forParameter:NSOpenGLContextParameterSwapRectangleEnable];
 }


### PR DESCRIPTION
I added a few things to [gemmacoswindow] in an attempt to minimize the aliasing that was occurring. reading up (1) i see that NSOpenGLPFAMultisample is supposed to do something so its a bunch of that kind of thing. Seems to look "better" but not perfect so not sure if this is as good as it gets?

(1)https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_fsaa/opengl_fsaa.html