### PR TITLE
Help: Recommend explicit colorspace selection in film and chromakey

### DIFF
--- a/help/pix_chroma_key-help.pd
+++ b/help/pix_chroma_key-help.pd
@@ -1,19 +1,19 @@
-#N canvas 280 61 632 502 10;
+#N canvas 207 93 659 563 10;
 #X declare -lib Gem;
 #X text 442 8 GEM object;
-#X obj 8 277 cnv 15 430 210 empty empty empty 20 12 0 14 -233017 -66577
+#X obj 8 328 cnv 15 430 210 empty empty empty 20 12 0 14 -233017 -66577
 0;
-#X text 39 277 Inlets:;
-#X text 42 451 Outlets:;
-#X obj 8 241 cnv 15 430 30 empty empty empty 20 12 0 14 -195568 -66577
+#X text 39 328 Inlets:;
+#X text 42 502 Outlets:;
+#X obj 8 292 cnv 15 430 30 empty empty empty 20 12 0 14 -195568 -66577
 0;
-#X text 17 240 Arguments:;
-#X obj 8 56 cnv 15 430 180 empty empty empty 20 12 0 14 -233017 -66577
+#X text 17 291 Arguments:;
+#X obj 8 56 cnv 15 430 230 empty empty empty 20 12 0 14 -233017 -66577
 0;
-#X obj 449 77 cnv 15 170 320 empty empty empty 20 12 0 14 -228992 -66577
+#X obj 449 77 cnv 15 195 345 empty empty empty 20 12 0 14 -228992 -66577
 0;
 #X text 453 60 Example:;
-#X obj 518 410 cnv 15 100 60 empty empty empty 20 12 0 14 -195568 -66577
+#X obj 518 430 cnv 15 100 60 empty empty empty 20 12 0 14 -195568 -66577
 0;
 #N canvas 0 22 450 300 gemwin 0;
 #X obj 132 136 gemwin;
@@ -33,35 +33,35 @@
 #X connect 5 0 1 0;
 #X connect 6 0 0 0;
 #X connect 7 0 0 0;
-#X restore 523 449 pd gemwin;
-#X msg 523 430 destroy;
-#X text 515 409 Create window:;
-#X obj 451 160 cnv 15 160 175 empty empty empty 20 12 0 14 -24198 -66577
+#X restore 523 469 pd gemwin;
+#X msg 523 450 destroy;
+#X text 515 429 Create window:;
+#X obj 451 185 cnv 15 160 175 empty empty empty 20 12 0 14 -24198 -66577
 0;
 #X obj 451 119 gemhead;
 #X obj 496 101 bng 15 250 50 0 empty empty pix_load 20 8 0 8 -262144
 -1 -1;
-#X obj 451 345 pix_texture;
-#X text 63 251 <none>;
-#X text 18 465 Outlet 1: gemlist;
-#X text 15 291 Inlet 1: gemlist;
-#X obj 451 373 square 3;
-#X obj 546 120 gemhead;
-#X obj 591 102 bng 15 250 50 0 empty empty empty 20 8 0 8 -262144 -1
+#X obj 451 370 pix_texture;
+#X text 63 302 <none>;
+#X text 18 516 Outlet 1: gemlist;
+#X text 15 342 Inlet 1: gemlist;
+#X obj 451 398 square 3;
+#X obj 580 120 gemhead;
+#X obj 625 102 bng 15 250 50 0 empty empty empty 20 8 0 8 -262144 -1
 -1;
-#X text 16 432 Inlet 2: gemlist;
+#X text 16 483 Inlet 2: gemlist;
 #X text 71 31 Class: pix mix object;
 #X text 50 12 Synopsis: [pix_chroma_key];
 #X text 29 57 Description: mix 2 images based on their color;
-#X obj 451 313 pix_chroma_key;
-#X msg 486 290 direction \$1;
-#X obj 486 270 tgl 15 1 empty empty empty 0 -6 0 8 -262144 -1 -1 0
+#X obj 451 338 pix_chroma_key;
+#X msg 486 315 direction \$1;
+#X obj 486 295 tgl 15 1 empty empty empty 0 -6 0 8 -262144 -1 -1 0
 1;
-#X text 16 390 Inlet 1: direction 0|1 : which stream is the key-source
+#X text 16 441 Inlet 1: direction 0|1 : which stream is the key-source
 (0=left stream \; 1 = right stream);
-#X floatatom 465 178 5 0 255 0 - - -;
-#X floatatom 475 230 5 0 255 0 - - -;
-#X text 37 197 The 2 images have to be of the same size.;
+#X floatatom 465 203 5 0 255 0 - - -;
+#X floatatom 475 255 5 0 255 0 - - -;
+#X text 15 197 The 2 images have to be of the same size.;
 #X text 14 76 [pix_chroma_key] does compositing using pixel by pixel
 comparisons on two video streams. the comparison is based on user a
 user supplied RGB or YUV pixel value and +/- range. if the pixel in
@@ -70,18 +70,18 @@ corresponding pixel im the other stream. typically this is most effective
 on a static background like a green/blue screen \, but can be effective
 when used with other GEM objects like pix_background for live video
 processing.;
-#X text 15 306 Inlet 1: value <list> : list of 3 floats of the pixel-value
+#X text 15 357 Inlet 1: value <list> : list of 3 floats of the pixel-value
 to key out: values are either Red/Green/Blue (in RGBA-Space) or Y(luma)/U(Cb)/V(Cr)
 in YUV-Space;
-#X text 16 346 Inlet 1: range <list> : list of 3 floats defining the
+#X text 16 397 Inlet 1: range <list> : list of 3 floats defining the
 +/-range of the key: values are either Red/Green/Blue (in RGBA-Space)
 or Y(luma)/U(Cb)/V(Cr) in YUV-Space;
-#X obj 478 216 hsl 128 12 0 1 0 0 empty empty empty -2 -8 0 10 -262144
+#X obj 478 241 hsl 128 12 0 1 0 0 empty empty empty -2 -8 0 10 -262144
 -1 -1 0 1;
-#X obj 468 163 hsl 128 12 0 1 0 0 empty empty empty -2 -8 0 10 -262144
+#X obj 468 188 hsl 128 12 0 1 0 0 empty empty empty -2 -8 0 10 -262144
 -1 -1 0 1;
-#X msg 465 195 value \$1 \$1 \$1;
-#X msg 475 248 range \$1 \$1 \$1;
+#X msg 465 220 value \$1 \$1 \$1;
+#X msg 475 273 range \$1 \$1 \$1;
 #N canvas 0 22 587 366 image 0;
 #X obj 77 48 inlet;
 #X obj 77 344 outlet;
@@ -122,10 +122,16 @@ time.;
 #X connect 7 0 6 0;
 #X connect 9 0 5 0;
 #X connect 10 0 9 0;
-#X restore 546 139 pd image;
-#X text 37 215 RGB values are 0-1 \, YUV values are 16/255-239/255
-;
+#X restore 580 139 pd image;
 #X obj 508 8 declare -lib Gem;
+#X text 15 215 RGB values are 0-1 \, YUV values are 16/255-239/255.
+It is strongly advised to convert explicitly to your preferred colorspace
+before [pix_chroma_key] (or open the image/video with a specific colorspace)
+because the default colorspace is not guaranteed to be the same across
+operating systems.;
+#X obj 451 161 pix_rgba;
+#X obj 580 162 pix_rgba;
+#X text 511 155 or [pix_yuv], f 9;
 #X connect 10 0 11 0;
 #X connect 11 0 10 0;
 #X connect 14 0 41 0;
@@ -142,5 +148,7 @@ time.;
 #X connect 38 0 31 0;
 #X connect 39 0 27 0;
 #X connect 40 0 27 0;
-#X connect 41 0 27 0;
-#X connect 43 0 27 1;
+#X connect 41 0 46 0;
+#X connect 43 0 47 0;
+#X connect 46 0 27 0;
+#X connect 47 0 27 1;

--- a/help/pix_chroma_key-help.pd
+++ b/help/pix_chroma_key-help.pd
@@ -124,14 +124,14 @@ time.;
 #X connect 10 0 9 0;
 #X restore 580 139 pd image;
 #X obj 508 8 declare -lib Gem;
-#X text 15 215 RGB values are 0-1 \, YUV values are 16/255-239/255.
-It is strongly advised to convert explicitly to your preferred colorspace
-before [pix_chroma_key] (or open the image/video with a specific colorspace)
-because the default colorspace is not guaranteed to be the same across
-operating systems.;
 #X obj 451 161 pix_rgba;
 #X obj 580 162 pix_rgba;
 #X text 511 155 or [pix_yuv], f 9;
+#X text 15 215 RGB values are 0-1 \, YUV values are 16/255-239/255.
+It is strongly advised to convert explicitly to your preferred colorspace
+before [pix_chroma_key] because the default colorspace is not guaranteed
+to be the same across operating systems (see [pix_rgba] or [pix_yuv]).
+;
 #X connect 10 0 11 0;
 #X connect 11 0 10 0;
 #X connect 14 0 41 0;
@@ -148,7 +148,7 @@ operating systems.;
 #X connect 38 0 31 0;
 #X connect 39 0 27 0;
 #X connect 40 0 27 0;
-#X connect 41 0 46 0;
-#X connect 43 0 47 0;
-#X connect 46 0 27 0;
-#X connect 47 0 27 1;
+#X connect 41 0 45 0;
+#X connect 43 0 46 0;
+#X connect 45 0 27 0;
+#X connect 46 0 27 1;

--- a/help/pix_film-help.pd
+++ b/help/pix_film-help.pd
@@ -61,10 +61,10 @@
 used as a texture \, bitblit or something else., f 69;
 #X text 64 249 symbol: file to load initially;
 #X text 18 303 Inlet 1: message: open <filename> [RGBA|YUV|Grey]: opens
-the movie <filename> and decodes it into the specified color-space.
+the movie <filename> \, decodes it into the specified color-space if supported.
 , f 69;
 #X text 18 336 Inlet 1: message: colorspace "RGBA|YUV|Grey": decodes
-the current film into the specified colorspace., f 69;
+the current film into the specified colorspace \, if supported., f 69;
 #X text 18 365 Inlet 1: message : auto 1|0 : starts/stops automatic
 playback. (default:0), f 69;
 #X text 17 576 Outlet 3: bang: indicates that the last frame has been
@@ -160,17 +160,22 @@ on rendering (starting with 0), f 69;
 #X text 17 391 Inlet 1: message : loader <name>: open the film using
 only the specified backend(s), f 70;
 #X obj 578 8 declare -lib Gem;
-#N canvas 2 93 450 300 :: 0;
+#N canvas 2 93 450 310 :: 0;
+#X text 35 220 If a specific colorspace is required \, it is strongly
+recommended to convert using [pix_rgba] \, [pix_yuv] \, [pix_grey]
+etc. This is the only way to guarantee a colorspace., f 60;
 #X text 35 33 Note that the default colorspace may vary on different
 operating systems \, even for the same patch and same video file. For
 instance \, [pix_film] may output YUV images in macOS \, while the
-same patch and same video file may obtain RGB images in Linux.;
-#X text 35 113 It is strongly recommended \, then \, to specify the
-colorspace explicitly. While most downstream [pix] objects can adapt
-automatically to the incoming format \, there are some (e.g. [pix_chroma_key])
-which take a user-specified color as an input. Such objects are sensitive
-to the image's colorspace \, and patches using them may exhibit variable
-behavior on different OSes.;
+same patch and same video file may obtain RGB images in Linux. While
+most downstream [pix] objects can adapt automatically to the incoming
+format \, there are some (e.g. [pix_chroma_key]) which take a user-specified
+color as an input. Such objects are sensitive to the image's colorspace
+\, and patches using them may exhibit variable behavior on different
+OSes.;
+#X text 35 172 Note also that codecs may choose to disregard the colorspace
+symbol given to pix_film -- you may or may not get the requested colorspace.
+;
 #X restore 211 130 pd :: COLORSPACES;
 #X text 13 104 You can open a specified film via the "open" message
 \, which takes an optional argument for the colorspace \, to which

--- a/help/pix_film-help.pd
+++ b/help/pix_film-help.pd
@@ -1,4 +1,4 @@
-#N canvas 163 146 704 623 10;
+#N canvas 163 143 704 623 10;
 #X declare -lib Gem;
 #X text 452 8 GEM object;
 #X obj 9 272 cnv 15 430 340 empty empty empty 20 12 0 14 -233017 -66577
@@ -36,7 +36,7 @@
 #X restore 599 479 pd gemwin;
 #X msg 599 460 create;
 #X text 595 439 Create window:;
-#X obj 451 88 cnv 15 175 300 empty empty empty 20 12 0 14 -24198 -66577
+#X obj 451 88 cnv 15 215 300 empty empty empty 20 12 0 14 -24198 -66577
 0;
 #X obj 451 63 gemhead;
 #X text 17 503 Outlet 1: gemlist;
@@ -55,7 +55,6 @@
 #X text 71 31 Class: pix object (pix source);
 #X text 29 57 Description: load in a movie-file;
 #X obj 463 117 openpanel;
-#X msg 463 136 open \$1;
 #X obj 451 432 rectangle 4 3;
 #X text 50 12 Synopsis: [pix_film];
 #X text 15 78 [pix_film] loads in a preproduced digital-video to be
@@ -74,13 +73,10 @@ reached. (or: an illegal frame would have been decoded), f 69;
 #X obj 469 156 tgl 15 0 empty empty empty 0 -6 0 8 -262144 -1 -1 0
 1;
 #X msg 480 193 colorspace Grey;
-#X text 13 104 You can open a specified film via the "open" message
-\, which takes an optional argument for the colorspace \, to which
-the movie should be decoded (RGBA \, YUV or Grey)., f 70;
 #X text 17 520 Outlet 2: list: <length> <width> <height> <fps>: gets
 the dimensions (in frames and pixels) of a film when it gets loaded.
 if length is not available (video-streams) -1 is returned., f 69;
-#N canvas 18 78 928 614 :: 0;
+#N canvas 18 93 928 614 :: 0;
 #X text 24 16 the format [pix_film] is able to decode depends on the
 system you are running Gem.;
 #X text 33 52 basically Gem's decoding capabilities are handled by
@@ -164,23 +160,40 @@ on rendering (starting with 0), f 69;
 #X text 17 391 Inlet 1: message : loader <name>: open the film using
 only the specified backend(s), f 70;
 #X obj 578 8 declare -lib Gem;
+#N canvas 2 93 450 300 :: 0;
+#X text 35 33 Note that the default colorspace may vary on different
+operating systems \, even for the same patch and same video file. For
+instance \, [pix_film] may output YUV images in macOS \, while the
+same patch and same video file may obtain RGB images in Linux.;
+#X text 35 113 It is strongly recommended \, then \, to specify the
+colorspace explicitly. While most downstream [pix] objects can adapt
+automatically to the incoming format \, there are some (e.g. [pix_chroma_key])
+which take a user-specified color as an input. Such objects are sensitive
+to the image's colorspace \, and patches using them may exhibit variable
+behavior on different OSes.;
+#X restore 211 130 pd :: COLORSPACES;
+#X text 13 104 You can open a specified film via the "open" message
+\, which takes an optional argument for the colorspace \, to which
+the movie should be decoded (RGBA \, YUV or Grey). See, f 70;
+#X msg 463 136 open \$1 RGBA;
+#X text 546 129 Recommended to specify colorspace!, f 20;
 #X connect 10 0 11 0;
 #X connect 11 0 10 0;
-#X connect 14 0 46 0;
-#X connect 17 0 30 0;
+#X connect 14 0 44 0;
+#X connect 17 0 29 0;
 #X connect 18 0 28 0;
-#X connect 25 0 46 1;
-#X connect 28 0 29 0;
-#X connect 29 0 46 0;
-#X connect 38 0 46 0;
-#X connect 39 0 38 0;
-#X connect 40 0 46 0;
-#X connect 44 0 21 0;
-#X connect 44 1 22 0;
-#X connect 44 2 23 0;
-#X connect 44 3 45 0;
-#X connect 46 0 17 0;
-#X connect 46 1 44 0;
-#X connect 46 2 24 0;
-#X connect 47 0 46 0;
-#X connect 51 0 46 0;
+#X connect 25 0 44 1;
+#X connect 28 0 54 0;
+#X connect 37 0 44 0;
+#X connect 38 0 37 0;
+#X connect 39 0 44 0;
+#X connect 42 0 21 0;
+#X connect 42 1 22 0;
+#X connect 42 2 23 0;
+#X connect 42 3 43 0;
+#X connect 44 0 17 0;
+#X connect 44 1 42 0;
+#X connect 44 2 24 0;
+#X connect 45 0 44 0;
+#X connect 49 0 44 0;
+#X connect 54 0 44 0;

--- a/help/pix_video-help.pd
+++ b/help/pix_video-help.pd
@@ -17,7 +17,7 @@
 #X text 17 486 Outlet 1: gemlist;
 #X text 17 198 Inlet 1: gemlist;
 #X text 16 308 Inlet 1: colorspace "RGBA|YUV|Grey": decodes the current
-film into the specified colorspace.;
+film into the specified colorspace \, if supported by the backend., f 62;
 #X text 64 159 none;
 #X text 33 184 Inlet:;
 #X text 33 472 Outlet:;


### PR DESCRIPTION
Per #282 -- users may reasonably expect compatible behavior in the same patch + image source files across the supported OSes.

But this is not always guaranteed, without explicitly specifying a colorspace.

I was unable to locate any documentation to this effect -- [pix_film] does mention opening the file with a colorspace, but the example doesn't do so, and it doesn't highlight the importance of doing so -- so I added some notes (especially for [pix_chroma_key], where it's rather confusing for users if they e.g. created a patch in Linux matching RGB values, and then macOS feeds YUV colors to it).