### PR TITLE
Fix crash when reloading model

### DIFF
--- a/src/Gem/model.cpp
+++ b/src/Gem/model.cpp
@@ -146,8 +146,16 @@ namespace
       } else {
         vTexCoordsUV = vTexCoordsLinear;
       }
-
     }
+    
+    void destroy()
+    {
+      vertices.destroy();
+      normals.destroy();
+      colors.destroy();
+      texcoords.destroy();
+    }
+    
     void update(enum gem::modelGL::texturetype t, float texW, float texH)
     {
       vertices.update(size, vVertices.data());
@@ -292,6 +300,12 @@ namespace gem {
     delete m_pimpl;
   }
 
+  void modelGL::destroy(void) {
+    for (auto& m: m_pimpl->mesh) {
+      m.destroy();
+    }
+  }
+
   bool modelGL::update(void) {
     m_pimpl->update = false;
     if(true) {
@@ -322,6 +336,7 @@ namespace gem {
     }
     render(groups);
   }
+
   void modelGL::render(std::vector<unsigned int>&meshes) {
     if(m_pimpl->update) update();
 

--- a/src/Gem/model.h
+++ b/src/Gem/model.h
@@ -35,7 +35,8 @@ namespace gem
     modelGL(gem::plugins::modelloader&loader);
     virtual ~modelGL(void);
 
-
+    /* destroy VBOs */
+    void destroy(void);
     /* update data */
     bool update(void);
     /* render the model in the current openGL context */

--- a/src/Geos/model.cpp
+++ b/src/Geos/model.cpp
@@ -521,6 +521,14 @@ void model :: startRendering()
   if(m_loaded)
     m_loaded->update();
 }
+
+void model :: stopRendering()
+{
+  if(m_loaded)
+    m_loaded->destroy();
+}
+
+
 /////////////////////////////////////////////////////////
 // render
 //

--- a/src/Geos/model.h
+++ b/src/Geos/model.h
@@ -100,6 +100,7 @@ protected:
   //////////
   virtual void  render(GemState *state);
   virtual void  startRendering();
+  virtual void  stopRendering();
 
   gem::plugins::modelloader*m_loader;
   gem::modelGL*m_loaded;


### PR DESCRIPTION
Found a bug while porting Gem over to plugdata, it also seems to affect the regular pure-data version of Gem.

When we stop rendering, we need to destroy the model data, because otherwise it will hold on to VBOs that are no longer valid after the openGL context is destroyed. This causes all examples that use models to crash if you close and re-open the window.