### PR TITLE
Prevent deleting a non-existent framebuffer

### DIFF
--- a/src/Controls/gemframebuffer.cpp
+++ b/src/Controls/gemframebuffer.cpp
@@ -469,6 +469,7 @@ void gemframebuffer :: initFBO()
 /////////////////////////////////////////////////////////
 void gemframebuffer :: destroyFBO()
 {
+  if(!m_haveinit) return;
   //if(!GLEW_EXT_framebuffer_object)return;
 
   // Release all resources.


### PR DESCRIPTION
I noticed that if we close the window first and then delete [gemframebuffer], it will destroy the FBO twice. AFAIK this doesn't directly causes crashes, but I also don't think this is well-defined behaviour either.