### PR TITLE
install missing Atom.h

### DIFF
--- a/src/RTE/Makefile.am
+++ b/src/RTE/Makefile.am
@@ -23,6 +23,7 @@ libRTE_la_includedir = $(includedir)/Gem/RTE
 libRTE_la_include_HEADERS = \
 	RTE.h \
 	Array.h \
+        Atom.h \
 	MessageCallbacks.h
 
 


### PR DESCRIPTION
during exhibition setup at the grand palais paris, @ch-nry discovered an annoying issue, `RTE/Atom.h` is not installed while `Base/CPPExtern.h` requires it.
Hence building a 3rdparty external fails. 
This PR install `RTE/Atom.h` and fixes the issue.
