### PR TITLE
part_info should not be responsible for paticles movement.

### DIFF
--- a/src/Particles/part_info.cpp
+++ b/src/Particles/part_info.cpp
@@ -87,9 +87,9 @@ part_info :: ~part_info()
 /////////////////////////////////////////////////////////
 void part_info :: renderParticles(GemState *state)
 {
-  if (m_tickTime > 0.f)    {
-    pMove();
-  }
+//  if (m_tickTime > 0.f)    {
+//    pMove();
+//  }
   //    pDrawGroupp();
   int cnt = pGetGroupCount();
   if(cnt < 1) {


### PR DESCRIPTION
pMove() is executed in part_render and part_draw.
This commit removes it from part_info.