### PR TITLE
Fix multitexture texture coordinates (bug #439)

### DIFF
--- a/examples/10.glsl/shader/multitexture_rect.frag
+++ b/examples/10.glsl/shader/multitexture_rect.frag
@@ -9,6 +9,6 @@ varying vec2 texcoord2;
 void main (void)
 {
  vec4 color = texture2DRect(MyTex,  texcoord1);
- vec4 color2 = texture2DRect(MyTex1, texcoord1); // texcoord2 does not work.
+ vec4 color2 = texture2DRect(MyTex1, texcoord2); 
  gl_FragColor = (color + color2) / 2.;
 }

--- a/src/Base/GemShape.cpp
+++ b/src/Base/GemShape.cpp
@@ -125,10 +125,12 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
   TexCoord*texcoordsPerUnit=NULL;
   int numCoords = 0;
   int numUnits = 0;
+  int texPerUnit = 0;
 
   state->get(GemState::_GL_TEX_NUMCOORDS, numCoords);
   state->get(GemState::_GL_TEX_UNITS, numUnits);
   state->get(GemState::_GL_TEX_COORDS_PER_UNIT, texcoordsPerUnit);
+  state->get(GemState::_GL_TEX_PER_UNIT, texPerUnit);
 
   if (numCoords) {
     tx=state->texCoordX(curCoord);
@@ -137,8 +139,8 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
 
   if (numUnits) {
     for(int i=0; i<numUnits; i++) {
-      // Use per-unit coordinates if available, otherwise use default coordinates
-      if(texcoordsPerUnit && curCoord < 4) {
+      // Use per-unit coordinates if flag is set and available, otherwise use default coordinates
+      if(texPerUnit && texcoordsPerUnit && curCoord < 4) {
         // Interpreted as 2D array: texcoordsPerUnit[i][curCoord]
         glMultiTexCoord2fARB(GL_TEXTURE0+i, texcoordsPerUnit[i*4 + curCoord].s, texcoordsPerUnit[i*4 + curCoord].t);
       } else {
@@ -157,11 +159,13 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
 {
   int numCoords = 0;
   int numUnits = 0;
+  int texPerUnit = 0;
   TexCoord*texcoordsPerUnit=NULL;
 
   state->get(GemState::_GL_TEX_NUMCOORDS, numCoords);
   state->get(GemState::_GL_TEX_UNITS, numUnits);
   state->get(GemState::_GL_TEX_COORDS_PER_UNIT, texcoordsPerUnit);
+  state->get(GemState::_GL_TEX_PER_UNIT, texPerUnit);
 
   if (numCoords) {
     s*=state->texCoordX(curCoord);
@@ -170,8 +174,8 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
 
   if (numUnits) {
     for(int i=0; i<numUnits; i++) {
-      // Use per-unit coordinates if available, otherwise use default coordinates
-      if(texcoordsPerUnit && curCoord < 4) {
+      // Use per-unit coordinates if flag is set and available, otherwise use default coordinates
+      if(texPerUnit && texcoordsPerUnit && curCoord < 4) {
         // Interpreted as 2D array: texcoordsPerUnit[i][curCoord]
         glMultiTexCoord4fARB(GL_TEXTURE0+i, texcoordsPerUnit[i*4 + curCoord].s, texcoordsPerUnit[i*4 + curCoord].t, r, q);
       } else {
@@ -181,7 +185,6 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
   } else { // no multitexturing!
     glTexCoord4f(s, t, r, q);
   }
-
   glVertex3f( x, y, z );
 }
 

--- a/src/Base/GemShape.cpp
+++ b/src/Base/GemShape.cpp
@@ -122,12 +122,13 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
                            float tx, float ty,int curCoord)
 {
   TexCoord*texcoords=NULL;
+  TexCoord*texcoordsPerUnit=NULL;
   int numCoords = 0;
   int numUnits = 0;
 
   state->get(GemState::_GL_TEX_NUMCOORDS, numCoords);
   state->get(GemState::_GL_TEX_UNITS, numUnits);
-
+  state->get(GemState::_GL_TEX_COORDS_PER_UNIT, texcoordsPerUnit);
 
   if (numCoords) {
     tx=state->texCoordX(curCoord);
@@ -136,7 +137,13 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
 
   if (numUnits) {
     for(int i=0; i<numUnits; i++) {
-      glMultiTexCoord2fARB(GL_TEXTURE0+i, tx, ty);
+      // Use per-unit coordinates if available, otherwise use default coordinates
+      if(texcoordsPerUnit && curCoord < 4) {
+        // Interpreted as 2D array: texcoordsPerUnit[i][curCoord]
+        glMultiTexCoord2fARB(GL_TEXTURE0+i, texcoordsPerUnit[i*4 + curCoord].s, texcoordsPerUnit[i*4 + curCoord].t);
+      } else {
+        glMultiTexCoord2fARB(GL_TEXTURE0+i, tx, ty);
+      }
     }
   } else { // no multitexturing!
     glTexCoord2f(tx, ty);
@@ -150,9 +157,11 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
 {
   int numCoords = 0;
   int numUnits = 0;
+  TexCoord*texcoordsPerUnit=NULL;
 
   state->get(GemState::_GL_TEX_NUMCOORDS, numCoords);
   state->get(GemState::_GL_TEX_UNITS, numUnits);
+  state->get(GemState::_GL_TEX_COORDS_PER_UNIT, texcoordsPerUnit);
 
   if (numCoords) {
     s*=state->texCoordX(curCoord);
@@ -161,7 +170,13 @@ void GemShape :: SetVertex(GemState* state,float x, float y, float z,
 
   if (numUnits) {
     for(int i=0; i<numUnits; i++) {
-      glMultiTexCoord4fARB(GL_TEXTURE0+i, s, t, r, q);
+      // Use per-unit coordinates if available, otherwise use default coordinates
+      if(texcoordsPerUnit && curCoord < 4) {
+        // Interpreted as 2D array: texcoordsPerUnit[i][curCoord]
+        glMultiTexCoord4fARB(GL_TEXTURE0+i, texcoordsPerUnit[i*4 + curCoord].s, texcoordsPerUnit[i*4 + curCoord].t, r, q);
+      } else {
+        glMultiTexCoord4fARB(GL_TEXTURE0+i, s, t, r, q);
+      }
     }
   } else { // no multitexturing!
     glTexCoord4f(s, t, r, q);

--- a/src/Gem/State.h
+++ b/src/Gem/State.h
@@ -74,6 +74,7 @@ public:
     _GL_TEX_UNITS,       /* "tex.units" <int> # of texUnits */
     _GL_TEX_ORIENTATION, /* "tex.orientation" <bool> false=bottomleft; true=topleft */
     _GL_TEX_BASECOORD,   /* "tex.basecoords" <TexCoord> width/height of texture  */
+    _GL_TEX_COORDS_PER_UNIT, /* "tex.coords.perunit" <TexCoord*> array of texcoords per unit */
 
 
 

--- a/src/Gem/State.h
+++ b/src/Gem/State.h
@@ -75,6 +75,7 @@ public:
     _GL_TEX_ORIENTATION, /* "tex.orientation" <bool> false=bottomleft; true=topleft */
     _GL_TEX_BASECOORD,   /* "tex.basecoords" <TexCoord> width/height of texture  */
     _GL_TEX_COORDS_PER_UNIT, /* "tex.coords.perunit" <TexCoord*> array of texcoords per unit */
+    _GL_TEX_PER_UNIT, /* "tex.perunit" <int> flag to enable per-unit texture coordinates */
 
 
 

--- a/src/Pixes/pix_texture.cpp
+++ b/src/Pixes/pix_texture.cpp
@@ -65,6 +65,7 @@ pix_texture :: pix_texture()
     m_clientStorage(0), //have to do this due to texture corruption issues
     m_yuv(1),
     m_texunit(0),
+    m_texperunit(0),
     m_numTexUnits(0),
     m_numPbo(0), m_oldNumPbo(0), m_curPbo(0), m_pbo(NULL),
     m_upsidedown(false)
@@ -646,15 +647,19 @@ void pix_texture :: render(GemState *state)
   state->set(GemState::_GL_TEX_ORIENTATION, upsidedown);
 
   // Store per-unit coordinates for multitexture support
-  static TexCoord s_perUnitCoords[MAX_MULTITEX_ID][4];
-  setTexCoords(s_perUnitCoords[m_texunit], m_xRatio, m_yRatio, upsidedown);
-  state->set(GemState::_GL_TEX_COORDS_PER_UNIT, reinterpret_cast<TexCoord*>(s_perUnitCoords));
-  // Set number of tex units to the maximum used so far
-  static int s_maxTexUnit = 0;
-  if(m_texunit >= s_maxTexUnit) {
-    s_maxTexUnit = m_texunit + 1;
+  if(m_texperunit) {
+    static TexCoord s_perUnitCoords[MAX_MULTITEX_ID][4];
+    setTexCoords(s_perUnitCoords[m_texunit], m_xRatio, m_yRatio, upsidedown);
+    state->set(GemState::_GL_TEX_COORDS_PER_UNIT, reinterpret_cast<TexCoord*>(s_perUnitCoords));
+    // Set number of tex units to the maximum used so far
+    static int s_maxTexUnit = 0;
+    if(m_texunit >= s_maxTexUnit) {
+      s_maxTexUnit = m_texunit + 1;
+    }
+    state->set(GemState::_GL_TEX_UNITS, s_maxTexUnit);
+    // Set flag to enable per-unit coordinates in GemShape
+    state->set(GemState::_GL_TEX_PER_UNIT, 1);
   }
-  state->set(GemState::_GL_TEX_UNITS, s_maxTexUnit);
 
   sendExtTexture(m_textureObj, m_xRatio, m_yRatio, m_textureType,
                  upsidedown);
@@ -904,6 +909,11 @@ void pix_texture :: texunitMess(int unit)
   m_texunit=unit;
 }
 
+void pix_texture :: texperunitMess(int mode)
+{
+  m_texperunit = (mode != 0);
+}
+
 ////////////////////////////////////////////////////////
 // static member functions
 //
@@ -923,6 +933,7 @@ void pix_texture :: obj_setupCallback(t_class *classPtr)
   CPPEXTERN_MSG1(classPtr, "pbo", pboMess, int);
 
   CPPEXTERN_MSG1(classPtr, "texunit", texunitMess, int);
+  CPPEXTERN_MSG1(classPtr, "texperunit", texperunitMess, int);
 
   CPPEXTERN_MSG (classPtr, "extTexture", extTextureMess);
 

--- a/src/Pixes/pix_texture.cpp
+++ b/src/Pixes/pix_texture.cpp
@@ -17,6 +17,8 @@
 
 #include "pix_texture.h"
 
+#define MAX_MULTITEX_ID 32
+
 #include "Gem/Settings.h"
 #include "Gem/Image.h"
 #include "Utils/Functions.h"
@@ -642,6 +644,17 @@ void pix_texture :: render(GemState *state)
   m_baseCoord.t=m_yRatio;
   state->set(GemState::_GL_TEX_BASECOORD, m_baseCoord);
   state->set(GemState::_GL_TEX_ORIENTATION, upsidedown);
+
+  // Store per-unit coordinates for multitexture support
+  static TexCoord s_perUnitCoords[MAX_MULTITEX_ID][4];
+  setTexCoords(s_perUnitCoords[m_texunit], m_xRatio, m_yRatio, upsidedown);
+  state->set(GemState::_GL_TEX_COORDS_PER_UNIT, reinterpret_cast<TexCoord*>(s_perUnitCoords));
+  // Set number of tex units to the maximum used so far
+  static int s_maxTexUnit = 0;
+  if(m_texunit >= s_maxTexUnit) {
+    s_maxTexUnit = m_texunit + 1;
+  }
+  state->set(GemState::_GL_TEX_UNITS, s_maxTexUnit);
 
   sendExtTexture(m_textureObj, m_xRatio, m_yRatio, m_textureType,
                  upsidedown);

--- a/src/Pixes/pix_texture.h
+++ b/src/Pixes/pix_texture.h
@@ -102,6 +102,7 @@ public:
   void yuvMess(int mode);
 
   void texunitMess(int unit);
+  void texperunitMess(int mode);
 
   void extTextureMess(t_symbol*, int, t_atom*);
 
@@ -140,6 +141,7 @@ protected:
   m_yuv; // try to texture YUV-images directly when gfx-card says it is possible to do so
 
   GLint m_texunit; // which texture unit to use
+  int m_texperunit; // whether to use per-unit texture coordinates (0=default, 1=enabled)
 
   /* CAPABILITIES */
 


### PR DESCRIPTION
When using multiple texture with shader, only the coordinate of the 1st textures was correct. 
see : 
https://github.com/umlaeute/Gem/issues/439
Well, in fact, in rectangle 0 mode, the 1st texture coordinate was working only for power of 2 image size.

This patch fix them when using multiple pix_texture. It did not change anything when using pix_multitexture.

The default (bad) behaviors is here since so long that changing it will break few patch.  This is a huge improvement, but should we keep the old behaviors in a compatibility mode? (should we keep the old behaviors as default?)

test : 
open examples/10.glsl/5.multitexture.pd
load image with different size that are not power of 2.

change glsl shader/multitexture; to glsl shader/multitexture_rect;
and both occurrence of rectangle 0 to rectangle 1

In both tests, the images are not correctly mapped on the square with current master, but are with this commit.

EDIT : use the correct help file for the test